### PR TITLE
Add repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.1"
 authors = ["Joshua R. Rodgers <bytemr@gmail.com>"]
 license = "Apache-2.0/MIT"
 description = "IRCv3 compatible client library using tokio and futures."
+repository = "https://github.com/Mr-Byte/tokio-irc-client"
 
 [features]
 tls = ["tokio-tls", "native-tls"]


### PR DESCRIPTION
(so that crates.io page links to the repo)