### PR TITLE
Update for reformed Tokio API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ tls = ["tokio-tls", "native-tls"]
 [dependencies]
 bytes = "0.4"
 futures = "0.1"
-tokio-core = "0.1"
-tokio-io = "0.1"
+tokio = "^0.1.11"
 error-chain = "0.10"
 pircolate = "0.2"
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -21,11 +21,12 @@ use native_tls::TlsConnector;
 
 use std::net::SocketAddr;
 use std::time;
+use std::marker;
 
 /// Represents a future, that when resolved provides an unecrypted `Stream`
 /// ([IrcTransport](struct.IrcTransport.html)) that can be used to receive
 /// `Message` from the server and send `Message` to the server.
-pub type BoxedStreamFuture = Box<Future<Item = IrcTransport<TcpStream>, Error = Error> + std::marker::Send + 'static>;
+pub type BoxedStreamFuture = Box<Future<Item = IrcTransport<TcpStream>, Error = Error> + marker::Send + 'static>;
 
 const PING_TIMEOUT_IN_SECONDS: u64 = 10 * 60;
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,5 +1,5 @@
 use bytes::BytesMut;
-use tokio_io::codec::{Decoder, Encoder};
+use tokio::codec::{Decoder, Encoder};
 
 use pircolate::Message;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,7 @@ extern crate error_chain;
 #[macro_use]
 extern crate futures;
 extern crate pircolate;
-extern crate tokio_core;
-extern crate tokio_io;
+extern crate tokio;
 
 #[cfg(feature = "tls")]
 extern crate native_tls;
@@ -46,7 +45,7 @@ mod codec;
 pub mod error;
 pub mod client;
 
-pub use client::{Client, ClientConnectFuture};
+pub use client::{Client, BoxedStreamFuture};
 #[cfg(feature = "tls")]
 pub use client::ClientConnectTlsFuture;
 pub use error::Error;


### PR DESCRIPTION
I've updated the library to work with the [Tokio reform](https://tokio.rs/blog/2018-02-tokio-reform-shipped/).

Examples have been updated accordingly, and from the little testing I've been able to do in my own application, the updated code seems to work fine. This is my first PR to another Rust project, so it's quite possible that I've overlooked some things :)

(This changes the return type of the `connect` method and is not compatible with pre-reform Tokio, so I suppose this would count as a breaking change.)